### PR TITLE
[TENI-70] Theme font and rebranding colors

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -46,7 +46,7 @@ html,
   -o-tab-size: 4;
      tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: "Proxima Nova", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -1754,7 +1754,7 @@ input:checked + .toggle-bg {
 
 .tc-bg-black {
   --tw-bg-opacity: 1;
-  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+  background-color: rgb(16 16 16 / var(--tw-bg-opacity));
 }
 
 .tc-bg-blue-50 {
@@ -2180,7 +2180,7 @@ input:checked + .toggle-bg {
 
 .tc-ring-black {
   --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(0 0 0 / var(--tw-ring-opacity));
+  --tw-ring-color: rgb(16 16 16 / var(--tw-ring-opacity));
 }
 
 .tc-ring-gray-300 {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 const colors = require("tailwindcss/colors");
+const defaultTheme = require("tailwindcss/defaultTheme")
 
 // Workaround for errors in consoles
 delete colors.lightBlue
@@ -45,7 +46,24 @@ module.exports = {
                 "apple": "#333333",
                 "playstore": "#01875f",
                 "vtd-primary": colors.sky, // Light mode Datepicker color
-                "vtd-secondary": colors.gray, // Dark mode Datepicker color
+                "vtd-secondary": colors.gray, // Dark mode Datepicker color,
+                "tendo-blue": "#3d9dff",
+                "tonik-purple": "#785aff",
+                "blue-1": "#3336e3",
+                "blue-2": "#555af1",
+                "blue-3": "#2e6aab",
+                "blue-4": "#2f196a",
+                "green-1": "#73f5d7",
+                "green-2": "#70d3a6",
+                "green-3": "#25d4db",
+                "green-4": "#01d2ed",
+                "pink": "#fd95f8",
+                "yellow-1": "#fcda85",
+                "yellow-2": "#cbce23",
+                "yellow-3": "#f7d365",
+                "black": "#101010",
+                "grey-1": "#a1b4c2",
+                "grey-2": "#f3f6f8"
             },
             screens: {
                 "max-sm": {
@@ -208,6 +226,9 @@ module.exports = {
                     },
                 },
             },
+            fontFamily: {
+                'sans': ['"Proxima Nova"', ...defaultTheme.fontFamily.sans]
+            }
         },
     },
     variants: [


### PR DESCRIPTION
update tailwind config to include proxima nova as font and add rebranding colors