### PR TITLE
[TENC-4476] Replace page select with number input to prevent DOM freeze

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - canvas

--- a/src/components/Table/TablePagination.vue
+++ b/src/components/Table/TablePagination.vue
@@ -46,20 +46,16 @@
           </div>
 
           <div class="tc-pl-3 tc-justify-center tc-inline-flex">
-            <select
+            <input
+              type="number"
               :value="pagination.current_page"
+              :min="1"
+              :max="pagination.last_page"
               data-test="pagination-select-page"
-              class="tc-justify-center tc-block tc-px-2 tc-py-1 tc-text-sm tc-border tc-border-gray-300 tc-rounded-md focus:tc-outline-none focus:tc-ring-2 focus:tc-ring-blue-500 focus:tc-border-blue-500"
+              class="tc-justify-center tc-block tc-w-16 tc-text-center tc-px-2 tc-py-1 tc-text-sm tc-border tc-border-gray-300 tc-rounded-md focus:tc-outline-none focus:tc-ring-2 focus:tc-ring-blue-500 focus:tc-border-blue-500"
               @change="goPage($event.target.value)"
-            >
-              <option
-                v-for="(option, index) in options(pagination.last_page)"
-                :key="index"
-                :value="option"
-              >
-                {{ option }}
-              </option>
-            </select>
+              @keyup.enter="goPage($event.target.value)"
+            />
           </div>
 
           <div class="tc-px-3 tc-justify-center tc-font-normal tc-text-xs">
@@ -117,15 +113,6 @@ const props = defineProps({
   }
 })
 
-function options(max) {
-  var result = [];
-
-  for (let i = 1; i <= max; i++) {
-    result.push(i);
-  }
-
-  return result;
-}
 
 const goPrev = () => {
   emit('page', props.pagination.current_page - 1)


### PR DESCRIPTION
https://tendopay.atlassian.net/browse/TENC-4476

## Summary                                                                                                                                                               
                                                                                                                                                                           
  - `TablePagination` generated all pages as `<option>` elements via a for loop (1 to `last_page`)                                                                         
  - With `last_page: 172,116`  for 3rd party > Xendit, this created 172K DOM nodes simultaneously, freezing the browser
  - Replaced `<select>` + `options()` with `<input type="number">` — same jump-to-page UX, single DOM element regardless of page count                                     
                                                                                                                                                                                                                                         
